### PR TITLE
Configuring http_proxy via function parameter instead of the environment

### DIFF
--- a/lib/duo.3
+++ b/lib/duo.3
@@ -11,7 +11,7 @@
 .Sh SYNOPSIS
 .Fd #include <duo.h>
 .Ft duo_t *
-.Fn duo_open "const char *ikey" "const char *skey" "const char *progname" "const char *cafile"
+.Fn duo_open "const char *ikey" "const char *skey" "const char *progname" "const char *cafile" "const char *http_proxy"
 .Ft void
 .Fn duo_set_conv_funcs "duo_t *d" "char *(*conv_prompt)(void *conv_arg, const char *, char *, size_t)" "void (*conv_status)(void *conv_arg, const char *msg)" "void *conv_arg"
 .Ft void
@@ -42,6 +42,10 @@ identifies the program to the Duo service.
 should be 
 .Li NULL
 or the pathname of a PEM-format CA certificate to override the default.
+.Fa http_proxy
+should be
+.Li NULL
+or URL to the desired HTTP proxy.
 .Pp
 .Fn duo_set_conv_funcs
 may be used to override the internal user conversation functions.

--- a/lib/duo.c
+++ b/lib/duo.c
@@ -79,7 +79,8 @@ __status_fn(void *arg, const char *msg)
 
 struct duo_ctx *
 duo_open(const char *host, const char *ikey, const char *skey,
-    const char *progname, const char *cafile, int https_timeout)
+    const char *progname, const char *cafile, int https_timeout,
+    const char *http_proxy)
 {
     struct duo_ctx *ctx;
         char *useragent;
@@ -92,7 +93,7 @@ duo_open(const char *host, const char *ikey, const char *skey,
                 progname, CANONICAL_HOST, PACKAGE_VERSION) == -1) {
         return (duo_close(ctx));
     }
-    if (https_init(ikey, skey, useragent, cafile) != HTTPS_OK) {
+    if (https_init(ikey, skey, useragent, cafile, http_proxy) != HTTPS_OK) {
                 ctx = duo_close(ctx);
     } else {
             ctx->conv_prompt = __prompt_fn;

--- a/lib/duo.h
+++ b/lib/duo.h
@@ -37,7 +37,8 @@ int	    duo_parse_config(const char *filename,
 
 /* Open Duo API handle */
 duo_t	   *duo_open(const char *host, const char *ikey, const char *skey,
-                     const char *progname, const char *cafile, int https_timeout);
+                     const char *progname, const char *cafile,
+                     int https_timeout, const char *http_proxy);
 
 /* Override conversation prompt/status functions */
 void	    duo_set_conv_funcs(duo_t *d,

--- a/lib/https.c
+++ b/lib/https.c
@@ -351,7 +351,8 @@ _establish_connection(struct https_request * const req,
 
 HTTPScode
 https_init(const char *ikey, const char *skey,
-    const char *useragent, const char *cafile)
+    const char *useragent, const char *cafile,
+    const char *http_proxy)
 {
         X509_STORE *store;
         X509 *cert;
@@ -417,8 +418,10 @@ https_init(const char *ikey, const char *skey,
                 }
                 SSL_CTX_set_verify(ctx->ssl_ctx, SSL_VERIFY_PEER, NULL);
         }
-        /* Save our proxy config if any */
-        if ((p = getenv("http_proxy")) != NULL) {
+        /* Setup our proxy config if any */
+        if (http_proxy != NULL) {
+                p = strdup(http_proxy);
+
                 if (strstr(p, "://") != NULL) {
                         if (strncmp(p, "http://", 7) != 0) {
                                 ctx->errstr = "http_proxy must be HTTP";
@@ -426,7 +429,6 @@ https_init(const char *ikey, const char *skey,
                         }
                         p += 7;
                 }
-                p = strdup(p);
                 
                 if ((ctx->proxy = strchr(p, '@')) != NULL) {
                         *ctx->proxy++ = '\0';

--- a/lib/https.c
+++ b/lib/https.c
@@ -443,6 +443,7 @@ https_init(const char *ikey, const char *skey,
                 } else {
                         ctx->proxy_port = "80";
                 }
+		free(p);
         }
         /* Set HTTP parser callbacks */
         ctx->parse_settings.on_body = __on_body;

--- a/lib/https.c
+++ b/lib/https.c
@@ -443,7 +443,6 @@ https_init(const char *ikey, const char *skey,
                 } else {
                         ctx->proxy_port = "80";
                 }
-		free(p);
         }
         /* Set HTTP parser callbacks */
         ctx->parse_settings.on_body = __on_body;

--- a/lib/https.h
+++ b/lib/https.h
@@ -20,7 +20,8 @@ typedef enum {
 
 /* Initialize HTTPS library */
 HTTPScode   https_init(const char *ikey, const char *skey,
-                       const char *useragent, const char *cafile);
+                       const char *useragent, const char *cafile,
+                       const char *http_proxy);
 
 /* Open HTTPS connection to host[:port] */
 HTTPScode   https_open(https_t **hp, const char *host);

--- a/lib/testduo.c
+++ b/lib/testduo.c
@@ -34,7 +34,7 @@ main(int argc, char *argv[])
                     "DUO_SKEY environment\n");
 		exit(1);
 	}
-	if ((duo = duo_open(host, ikey, skey, "testduo", NULL, DUO_NO_TIMEOUT)) == NULL) {
+	if ((duo = duo_open(host, ikey, skey, "testduo", NULL, DUO_NO_TIMEOUT, NULL)) == NULL) {
 		fprintf(stderr, "duo_open failed\n");
 		exit(1);
 	}

--- a/login_duo/login_duo.c
+++ b/login_duo/login_duo.c
@@ -183,16 +183,11 @@ do_auth(struct login_ctx *ctx, const char *cmd)
         }
     }
 
-    /* Honor configured http_proxy */
-    if (cfg.http_proxy != NULL) {
-        setenv("http_proxy", cfg.http_proxy, 1);
-    }
-
     /* Try Duo auth. */
     if ((duo = duo_open(cfg.apihost, cfg.ikey, cfg.skey,
                     "login_duo/" PACKAGE_VERSION,
                     cfg.noverify ? "" : cfg.cafile,
-                    cfg.https_timeout)) == NULL) {
+                    cfg.https_timeout, cfg.http_proxy)) == NULL) {
         duo_log(LOG_ERR, "Couldn't open Duo API handle",
             pw->pw_name, host, NULL);
         return (EXIT_FAILURE);

--- a/pam_duo/pam_duo.c
+++ b/pam_duo/pam_duo.c
@@ -327,7 +327,7 @@ pam_sm_authenticate(pam_handle_t *pamh, int pam_flags,
 	/* Try Duo auth */
 	if ((duo = duo_open(cfg.apihost, cfg.ikey, cfg.skey,
                     "pam_duo/" PACKAGE_VERSION,
-                    cfg.noverify ? "" : cfg.cafile, DUO_NO_TIMEOUT)) == NULL) {
+                    cfg.noverify ? "" : cfg.cafile, DUO_NO_TIMEOUT, cfg.http_proxy)) == NULL) {
 		duo_log(LOG_ERR, "Couldn't open Duo API handle", pw->pw_name, host, NULL);
 		return (PAM_SERVICE_ERR);
 	}


### PR DESCRIPTION
Proxy support in the Duo module was implemented by calling setenv() prior
to https_init(). It had the unintended side effect of setting http_proxy
in user environments, which could get picked up by userland software.

This was undesirable as some users would restart system applications and
pick up $http_proxy. This patch adds an argument to duo_open() /
https_init() which explicitly passes http_proxy as a variable instead of
relying on the processes' environment.